### PR TITLE
allow kayron to deploy itsel

### DIFF
--- a/infrastructure/infrastructure.yaml
+++ b/infrastructure/infrastructure.yaml
@@ -1,4 +1,5 @@
 - github: "infrastructure"
   provider: "cloudformation"
   deploy:
-    release: "v0.1.6"
+    release: "v0.1.5"
+    # release: "v0.1.6"

--- a/service/service.yaml
+++ b/service/service.yaml
@@ -1,7 +1,7 @@
-- docker: "splits-lite"
-  github: "splits-lite"
-  deploy:
-    release: "v0.1.0"
+# - docker: "splits-lite"
+#   github: "splits-lite"
+#   deploy:
+#     release: "v0.1.0"
 
 - docker: "kayron"
   github: "kayron"


### PR DESCRIPTION
I messed up the deployment order for Kayron. When I was testing the Splits Lite deployment I did everything at once and thought that Kayron can deploy itself even if the new Splits Lite deployment was present. That did not work. So I want to keep the `testing` environment as is, because all is setup there correctly, merge this change into `main` and get `staging` and `production` settled with the new Kayron version first. And then deploy the Splits Lite stacks through separately from `testing` again.