### PR TITLE
add splits lite deployment

### DIFF
--- a/infrastructure/infrastructure.yaml
+++ b/infrastructure/infrastructure.yaml
@@ -1,4 +1,4 @@
 - github: "infrastructure"
   provider: "cloudformation"
   deploy:
-    release: "v0.1.5"
+    release: "v0.1.6"

--- a/service/service.yaml
+++ b/service/service.yaml
@@ -1,3 +1,8 @@
+- docker: "splits-lite"
+  github: "splits-lite"
+  deploy:
+    release: "v0.1.0"
+
 - docker: "kayron"
   github: "kayron"
   deploy:


### PR DESCRIPTION
Towards https://linear.app/splits/issue/PE-4711/run-splits-lite-in-cloudformation-and-deploy-via-kayron. Due to the Kayron bug fix, I have to reintroduce this here. See the previous work at https://github.com/0xSplits/releases/pull/13.