### PR TITLE
PE-7055: bump alloy to v1.12.0-a556c51 and specta to v0.3.0

### DIFF
--- a/service/service.yaml
+++ b/service/service.yaml
@@ -1,7 +1,7 @@
 - docker: "alloy"
   github: "alloy"
   deploy:
-    release: "v1.11.3-9fba925"
+    release: "v1.12.0-a556c51"
 
 - docker: "kayron"
   github: "kayron"
@@ -11,7 +11,7 @@
 - docker: "specta"
   github: "specta"
   deploy:
-    release: "v0.2.6"
+    release: "v0.3.0"
 
 - docker: "splits-lite"
   github: "splits-lite"


### PR DESCRIPTION
## Summary

Pin the new alloy and specta releases that drop all Pulsar references:

| Service | Old | New |
|---|---|---|
| alloy | `v1.11.3-9fba925` | `v1.12.0-a556c51` |
| specta | `v0.2.6` | `v0.3.0` |

- alloy `v1.12.0-a556c51` removes the `splits_pulsar` scrape, `discovery.dns "pulsar"`, and the `.*-pulsar$` relabel rule (0xSplits/alloy#51).
- specta `v0.3.0` removes `pulsar` from the hard coded build/container/stack registries (0xSplits/specta#131).

Merge this first so kayron rolls out the new specta + alloy across all envs, then we can merge and deploy 0xSplits/infrastructure#68 (which tears down the `PulsarStack` itself).

Linear: PE-7055

🤖 Generated with [Claude Code](https://claude.com/claude-code)