### PR TITLE
PE-7055: bump infrastructure to v0.5.0

### DIFF
--- a/infrastructure/infrastructure.yaml
+++ b/infrastructure/infrastructure.yaml
@@ -1,4 +1,4 @@
 - github: "infrastructure"
   provider: "cloudformation"
   deploy:
-    release: "v0.4.15"
+    release: "v0.5.0"


### PR DESCRIPTION
## Summary

Pin the new infrastructure release that tears down the Pulsar CloudFormation stack: 0xSplits/infrastructure#68 (merged, tagged as `v0.5.0`).

| | Old | New |
|---|---|---|
| infrastructure | `v0.4.15` | `v0.5.0` |

Linear: PE-7055

🤖 Generated with [Claude Code](https://claude.com/claude-code)