### PR TITLE
test infra branch with indexing service discovery

### DIFF
--- a/infrastructure/infrastructure.yaml
+++ b/infrastructure/infrastructure.yaml
@@ -1,5 +1,4 @@
 - github: "infrastructure"
   provider: "cloudformation"
   deploy:
-    branch: "feature/infra-indexing-discovery-exports"
-    # release: "v0.5.0"
+    release: "v0.5.1"

--- a/infrastructure/infrastructure.yaml
+++ b/infrastructure/infrastructure.yaml
@@ -1,4 +1,5 @@
 - github: "infrastructure"
   provider: "cloudformation"
   deploy:
-    release: "v0.5.0"
+    branch: "feature/infra-indexing-discovery-exports"
+    # release: "v0.5.0"

--- a/service/service.yaml
+++ b/service/service.yaml
@@ -11,7 +11,7 @@
 - docker: "specta"
   github: "specta"
   deploy:
-    release: "v0.3.0"
+    release: "v0.3.1"
 
 - docker: "splits-lite"
   github: "splits-lite"

--- a/service/service.yaml
+++ b/service/service.yaml
@@ -1,7 +1,7 @@
 - docker: "alloy"
   github: "alloy"
   deploy:
-    release: "v1.12.0-a556c51"
+    release: "v1.12.1-fd79cf7"
 
 - docker: "kayron"
   github: "kayron"


### PR DESCRIPTION
Points the testing environment at the infra feature branch [`feature/infra-indexing-discovery-exports`](https://github.com/0xSplits/infrastructure/pull/69) so the indexing service discovery + Alloy env vars + PORT fix can be smoke-tested in the test environment before tagging an infra release.

Revert the `branch:` line back to the commented `release: "v0.5.0"` (or bump to a fresh tag) before merging to main.