### PR TITLE
bump splits-lite to v0.2.1

### DIFF
--- a/service/service.yaml
+++ b/service/service.yaml
@@ -16,5 +16,5 @@
 - docker: "splits-lite"
   github: "splits-lite"
   deploy:
-    release: "v0.2.0"
+    release: "v0.2.1"
     preview: true


### PR DESCRIPTION
## Summary
- Bumps `splits-lite` release pin from `v0.2.0` → `v0.2.1`.
- Release notes: https://github.com/0xSplits/splits-lite/releases/tag/v0.2.1

## Test plan
- [ ] Confirm deploy picks up the new tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)