### PR TITLE
Bump infrastructure to v0.5.2 (testing)

### DIFF
--- a/infrastructure/infrastructure.yaml
+++ b/infrastructure/infrastructure.yaml
@@ -1,4 +1,4 @@
 - github: "infrastructure"
   provider: "cloudformation"
   deploy:
-    release: "v0.5.1"
+    release: "v0.5.2"


### PR DESCRIPTION
Points the **testing** environment at infrastructure **v0.5.2** (was v0.5.1).

## What's in v0.5.2
- [#73](https://github.com/0xSplits/infrastructure/pull/73) — PE-7552 | Restore LB 5xx alarm threshold to original sensitivity
- [#72](https://github.com/0xSplits/infrastructure/pull/72) — Bump docker/login-action 4.1.0 → 4.2.0

Full changelog: https://github.com/0xSplits/infrastructure/compare/v0.5.1...v0.5.2

## Notes
- The `testing` branch had been deleted; I recreated it at its last state (`b83c889`, v0.5.1) so this PR shows a clean single-version diff.
- Per the releases README: once verified in testing, the next step is the same one-line bump on `main` (staging), then a release tag for prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)