### PR TITLE
PE-7693: bump alloy to v1.12.2-ce60d74

### DIFF
--- a/service/service.yaml
+++ b/service/service.yaml
@@ -1,7 +1,7 @@
 - docker: "alloy"
   github: "alloy"
   deploy:
-    release: "v1.12.1-fd79cf7"
+    release: "v1.12.2-ce60d74"
 
 - docker: "kayron"
   github: "kayron"


### PR DESCRIPTION
## Summary
- Bumps `alloy` release pin from `v1.12.1-fd79cf7` → `v1.12.2-ce60d74`.
- Release notes: https://github.com/0xSplits/alloy/releases/tag/v1.12.2-ce60d74

| Service | Old | New |
|---|---|---|
| alloy | `v1.12.1-fd79cf7` | `v1.12.2-ce60d74` |

alloy `v1.12.2-ce60d74` adds ElastiCache/Redis metrics scraping plus a Redis dashboard (0xSplits/alloy#60).

## Test plan
- [ ] Confirm deploy picks up the new tag

Linear: PE-7693

🤖 Generated with [Claude Code](https://claude.com/claude-code)