### PR TITLE
Release: Infrastructure v0.5.5

### DIFF
--- a/infrastructure/infrastructure.yaml
+++ b/infrastructure/infrastructure.yaml
@@ -1,4 +1,4 @@
 - github: "infrastructure"
   provider: "cloudformation"
   deploy:
-    release: "v0.5.4"
+    release: "v0.5.5"


### PR DESCRIPTION
Bumps the infrastructure CloudFormation release from `v0.5.4` to [`v0.5.5`](https://github.com/0xSplits/infrastructure/releases/tag/v0.5.5).

This updates the staging environment per the release process in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)