### PR TITLE
bump splits-lite to v0.2.2

### DIFF
--- a/service/service.yaml
+++ b/service/service.yaml
@@ -16,5 +16,5 @@
 - docker: "splits-lite"
   github: "splits-lite"
   deploy:
-    release: "v0.2.1"
+    release: "v0.2.2"
     preview: true


### PR DESCRIPTION
Updates `splits-lite` from `v0.2.1` to `v0.2.2` in `service/service.yaml`.

Targets the `testing` branch for staged rollout before `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)