### PR TITLE
Bump infrastructure to v0.5.8

### DIFF
--- a/infrastructure/infrastructure.yaml
+++ b/infrastructure/infrastructure.yaml
@@ -1,4 +1,4 @@
 - github: "infrastructure"
   provider: "cloudformation"
   deploy:
-    release: "v0.5.7"
+    release: "v0.5.8"


### PR DESCRIPTION
## What

Bump `infrastructure/infrastructure.yaml` from `v0.5.7` → `v0.5.8`.

`v0.5.8` adds the CodePipeline failed-deployment alert (infra #87): an EventBridge API Destination on each env's deploy-failure `EventRule` that POSTs to the backend's `/api/codepipeline/webhook`, which forwards to Discord.

## Effect

Merging this deploys `v0.5.8` to **staging** via kayron — creating the `DeployAlertConnection` + `DeployAlertApiDestination` in the staging DeploymentStack.

## Prereqs (already in place)

- Backend endpoint `/api/codepipeline/webhook` is live on staging.
- `CodePipelineWebhookSecret` (Secrets Manager) + `CODEPIPELINE_WEBHOOK_SECRET` (staging `ENV_CONSTANTS`) are set.
