### PR TITLE
Release: bump infrastructure to v0.5.9 and splits-lite to v0.2.5

### DIFF
--- a/infrastructure/infrastructure.yaml
+++ b/infrastructure/infrastructure.yaml
@@ -1,4 +1,4 @@
 - github: "infrastructure"
   provider: "cloudformation"
   deploy:
-    release: "v0.5.5"
+    release: "v0.5.6"

--- a/infrastructure/infrastructure.yaml
+++ b/infrastructure/infrastructure.yaml
@@ -1,4 +1,4 @@
 - github: "infrastructure"
   provider: "cloudformation"
   deploy:
-    release: "v0.5.7"
+    release: "v0.5.8"

--- a/infrastructure/infrastructure.yaml
+++ b/infrastructure/infrastructure.yaml
@@ -1,4 +1,4 @@
 - github: "infrastructure"
   provider: "cloudformation"
   deploy:
-    release: "v0.5.6"
+    release: "v0.5.7"

--- a/infrastructure/infrastructure.yaml
+++ b/infrastructure/infrastructure.yaml
@@ -1,4 +1,4 @@
 - github: "infrastructure"
   provider: "cloudformation"
   deploy:
-    release: "v0.5.8"
+    release: "v0.5.9"

--- a/service/service.yaml
+++ b/service/service.yaml
@@ -16,5 +16,5 @@
 - docker: "splits-lite"
   github: "splits-lite"
   deploy:
-    release: "v0.2.1"
+    release: "v0.2.2"
     preview: true

--- a/service/service.yaml
+++ b/service/service.yaml
@@ -16,5 +16,5 @@
 - docker: "splits-lite"
   github: "splits-lite"
   deploy:
-    release: "v0.2.3"
+    release: "v0.2.5"
     preview: true


### PR DESCRIPTION
Promotes the current `testing` state to `main`, bumping two services to their latest published GitHub releases.

## Bumps in this PR (the new commit)

| Service | From | To |
|---|---|---|
| `infrastructure` | v0.5.8 | **v0.5.9** |
| `splits-lite` | v0.2.3 | **v0.2.5** |

Both target releases are published, non-draft, non-prerelease.

## Also included

Because this is a `testing` → `main` PR, it also carries everything already staged on `testing` but not yet on `main` (prior infrastructure v0.5.7/v0.5.8 and splits-lite v0.2.2/v0.2.3 bumps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)